### PR TITLE
Optimize basic calendar object synchronization

### DIFF
--- a/lib/calendars.js
+++ b/lib/calendars.js
@@ -228,6 +228,70 @@ export let listCalendarObjects = co.wrap(function* (calendar, options) {
 });
 
 /**
+ * Fetch calendar objects that changed on the remote calendar since
+ * the last sync. This includes added, modified and deleted calendar
+ * objects. Changes will be recognized by comparing the etags in the
+ * `calendar.objects` array with the etags fetched from the remote.
+ *
+ * @param {dav.Calendar} calendar the calendar to fetch objects for.
+ *
+ * Options:
+ *
+ *   (Array.<Object>) filters - optional caldav filters.
+ *   (dav.Sandbox) sandbox - optional request sandbox.
+ *   (dav.Transport) xhr - request sender.
+ */
+export let syncCalendarObjects = co.wrap(function* (calendar, options) {
+  debug(`Sync objects on calendar ${calendar.url} which belongs to
+         ${calendar.account.credentials.username}`);
+
+  // First we only fetch the etags and hrefs to figure out what changed locally
+  let remoteCalendarObjects = yield listCalendarObjectsEtags(calendar, options);
+
+  // Collect hrefs of all new and modified events
+  const hrefs = [];
+
+  // Compare local calendar objects with remote calendar objects
+  const localEvents = calendar.objects;
+  const remoteEvents = remoteCalendarObjects.filter(
+    (obj) => obj.href && obj.href.length
+  );
+  remoteEvents.forEach((remoteEvent) => {
+    // Check if remote event already exists locally
+    const localEvent = localEvents.find((localEvent) =>
+      fuzzyUrlEquals(localEvent.url, remoteEvent.href)
+    );
+    if (localEvent) {
+      localEvent.exists = true;
+      if (localEvent.etag !== remoteEvent.etag) {
+        // Modified event
+        hrefs.push(remoteEvent.href);
+      }
+      // If etag matches, event did not change -> don't push them
+    } else {
+      // New event
+      hrefs.push(remoteEvent.href);
+    }
+  });
+  // Get the calendar-data and etags of the events that are either new or changed
+  options.hrefs = hrefs;
+  const calendarObjects = yield multigetCalendarObjects(calendar, options);
+
+  // Push deleted events
+  localEvents.forEach((event) => {
+    if (!event.exists) {
+      calendarObjects.push(
+        new CalendarObject({
+          url: event.url,
+          status: 'cancelled',
+        })
+      );
+    }
+  });
+  return calendarObjects;
+});
+
+/**
  * @param {dav.Calendar} calendar the calendar to fetch etags for.
  *
  * Options:
@@ -453,7 +517,7 @@ let basicSync = co.wrap(function* (calendar, options) {
   }
 
   debug('ctag changed so we need to fetch stuffs.');
-  calendar.objects = yield listCalendarObjects(calendar, options);
+  calendar.objects = yield syncCalendarObjects(calendar, options);
   return calendar;
 });
 


### PR DESCRIPTION
- `Client.syncCalendar` returns only modified events since the last sync instead of full calendar collection (based on etag matching)
